### PR TITLE
docs: Fix a few typos

### DIFF
--- a/jrpc/reflection.py
+++ b/jrpc/reflection.py
@@ -6,7 +6,7 @@ class RPCType(object):
 
     @staticmethod
     def ToDict(members):
-        """Converts an argument list [(name, type), (name, type)...] into a JSON serializble array"""
+        """Converts an argument list [(name, type), (name, type)...] into a JSON serializable array"""
         return [dict(name = attribute[0], **attribute[1].toDict()) for attribute in members]
 
     @staticmethod

--- a/jrpc/service.py
+++ b/jrpc/service.py
@@ -210,7 +210,7 @@ class SocketProxy(object):
             msg = message.Request(self.next_id, remote_procedure, [args, kwargs])
             self.next_id += 1
 
-            # Attempt sending and connection if neccessary
+            # Attempt sending and connection if necessary
             try:
                 msg.serialize(self.socket)
             except socket.error as e:


### PR DESCRIPTION
There are small typos in:
- jrpc/reflection.py
- jrpc/service.py

Fixes:
- Should read `serializable` rather than `serializble`.
- Should read `necessary` rather than `neccessary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md